### PR TITLE
refactor(not-found): introduce a proper and unique 'notFound' value

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "[javascript]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/__tests__/Optional.test.js
+++ b/__tests__/Optional.test.js
@@ -2,6 +2,7 @@ import { optic, maybe, preview, set, over } from '../src/operations'
 import { get, set as assoc, toUpper } from '../src/functions'
 import { optional, optionalProp, optionalIx } from '../src/Optional'
 import { prop } from '../src/Lens'
+import { notFound } from '../src/notFound'
 
 const friends = ['Alejandro']
 const user = { id: 1, name: 'Flavio' }
@@ -51,6 +52,24 @@ describe('Optional', () => {
     const firstFriendL = optic(maybe(prop('friends')), maybe(0))
 
     expect(preview(firstFriendL, userWithFriends)).toBe('Alejandro')
+  })
+
+  test('optionals with non-existing key should return notFound', () => {
+    const serventesioL = optionalProp('serventesio')
+
+    expect(preview(serventesioL, user)).toBe(notFound)
+  })
+
+  test('optionals with non-existing key should not change the value', () => {
+    const serventesioL = optionalProp('serventesio')
+
+    expect(over(serventesioL, toUpper, user)).toEqual(user)
+  })
+
+  test('optionals with one non-existing key should return notFound', () => {
+    const firstFriendL = optic(optionalProp('friends'), optionalIx(1000))
+
+    expect(preview(firstFriendL, userWithFriends)).toBe(notFound)
   })
 
   test('maybe should fail for wrong types', () => {

--- a/__tests__/Optional.test.js
+++ b/__tests__/Optional.test.js
@@ -73,6 +73,6 @@ describe('Optional', () => {
   })
 
   test('maybe should fail for wrong types', () => {
-    expect(maybe([1,2])).toBe(undefined)
+    expect(maybe([1, 2])).toBe(undefined)
   })
 })

--- a/__tests__/Prism.test.js
+++ b/__tests__/Prism.test.js
@@ -1,7 +1,7 @@
 import { notFound } from '../src/notFound'
 import { toUpper } from '../src/functions'
 import { optic, preview, over } from '../src/operations'
-import { has } from '../src/prism'
+import { has } from '../src/Prism'
 
 const user = { id: 1, name: 'Flavio' }
 

--- a/__tests__/Prism.test.js
+++ b/__tests__/Prism.test.js
@@ -1,0 +1,20 @@
+import { notFound } from '../src/notFound'
+import { toUpper } from '../src/functions'
+import { optic, preview, over } from '../src/operations'
+import { has } from '../src/prism'
+
+const user = { id: 1, name: 'Flavio' }
+
+describe('Prism', () => {
+  test('has returns itself if ok', () => {
+    expect(preview(has({id : 1}), user)).toEqual(user)
+  })
+
+  test('has returns nothing if not found', () => {
+    expect(preview(has({id : 2}), user)).toEqual(notFound)
+  })
+
+  test('has works correctly in composition', () => {
+    expect(over(optic(has({id: 1}), 'name'), toUpper, user)).toEqual({ id: 1, name: 'FLAVIO' })
+  })
+})

--- a/__tests__/functions.test.js
+++ b/__tests__/functions.test.js
@@ -1,4 +1,4 @@
-import { compose, curry, get, isNil, set, toUpper } from '../src/functions'
+import { compose, curry, get, set, toUpper } from '../src/functions'
 
 const cubed = (num, exp) => num ** exp
 const exp = curry(cubed)
@@ -8,16 +8,6 @@ describe('Function Operators', () => {
   test('curry -> should curry functions', () => {
     expect(exp(5)(3)).toBe(125)
   })
-
-  /* test('isNil -> should check if a value is null or undefined', () => {
-    expect(isNil(null)).toBe(true)
-    expect(isNil(undefined)).toBe(true)
-    expect(isNil('')).toBe(false)
-    expect(isNil(0)).toBe(false)
-    expect(isNil(-0)).toBe(false)
-    expect(isNil(false)).toBe(false)
-    expect(isNil(NaN)).toBe(false)
-  }) */
 
   test('compose -> should compose N functions correctly', () => {
     const inc = (x) => x + 1

--- a/__tests__/functions.test.js
+++ b/__tests__/functions.test.js
@@ -9,7 +9,7 @@ describe('Function Operators', () => {
     expect(exp(5)(3)).toBe(125)
   })
 
-  test('isNil -> should check if a value is null or undefined', () => {
+  /* test('isNil -> should check if a value is null or undefined', () => {
     expect(isNil(null)).toBe(true)
     expect(isNil(undefined)).toBe(true)
     expect(isNil('')).toBe(false)
@@ -17,7 +17,7 @@ describe('Function Operators', () => {
     expect(isNil(-0)).toBe(false)
     expect(isNil(false)).toBe(false)
     expect(isNil(NaN)).toBe(false)
-  })
+  }) */
 
   test('compose -> should compose N functions correctly', () => {
     const inc = (x) => x + 1

--- a/src/Optional.js
+++ b/src/Optional.js
@@ -1,6 +1,7 @@
 import { setter } from './Setter'
 import { partialGetter } from './PartialGetter'
-import { curry, get, set, isNil } from './functions'
+import { curry } from './functions'
+import { notFound, isNotFound } from './notFound'
 
 /**
  * AKA: Affine Traversal
@@ -13,7 +14,7 @@ class Optional {
 
   over = (f, obj) => {
     const v = this.preview(obj)
-    return isNil(v) ? obj : this.set(f(v), obj)
+    return isNotFound(v) ? obj : this.set(f(v), obj)
   }
 
   // setter = over + set
@@ -36,7 +37,13 @@ class Optional {
 export const optional = curry((preview, set) => new Optional(preview, set))
 
 // optionalProp : String → Optional s a
-export const optionalProp = (key) => optional(get(key), set(key))
+export const optionalProp = (key) => optional(
+  (obj)      => key in obj ? obj[key] : notFound,
+  (val, obj) => key in obj ? { ...obj, [key]: val } : obj
+)
 
-// optionalIndex : Number → Optional s a
-export const optionalIx = (index) => optional(get(index), set(index))
+// optionalIx : Number → Optional s a
+export const optionalIx = (index) => optional(
+  (obj)      => index in obj ? obj[index] : notFound,
+  (val, obj) => index in obj ? { ...obj, [index]: val } : obj
+)

--- a/src/Optional.js
+++ b/src/Optional.js
@@ -37,13 +37,15 @@ class Optional {
 export const optional = curry((preview, set) => new Optional(preview, set))
 
 // optionalProp : String → Optional s a
-export const optionalProp = (key) => optional(
-  (obj)      => key in obj ? obj[key] : notFound,
-  (val, obj) => key in obj ? { ...obj, [key]: val } : obj
-)
+export const optionalProp = (key) =>
+  optional(
+    (obj) => (key in obj ? obj[key] : notFound),
+    (val, obj) => (key in obj ? { ...obj, [key]: val } : obj),
+  )
 
 // optionalIx : Number → Optional s a
-export const optionalIx = (index) => optional(
-  (obj)      => index in obj ? obj[index] : notFound,
-  (val, obj) => index in obj ? { ...obj, [index]: val } : obj
-)
+export const optionalIx = (index) =>
+  optional(
+    (obj) => (index in obj ? obj[index] : notFound),
+    (val, obj) => (index in obj ? { ...obj, [index]: val } : obj),
+  )

--- a/src/Prism.js
+++ b/src/Prism.js
@@ -1,5 +1,5 @@
 import { curry } from './functions'
-import { isNotFound } from './notFound'
+import { notFound, isNotFound } from './notFound'
 import { setter } from './Setter'
 import { optional } from './Optional'
 import { reviewer } from './Reviewer'
@@ -45,3 +45,18 @@ class Prism {
 
 // prism : (s → Maybe a) → ((a, s) → s) → (a → s) → Prism s a
 export const prism = curry((preview, set, review) => new Prism(preview, set, review))
+
+const checkPresence = (mustBePresent, obj) =>
+  Object.keys(mustBePresent).every((k) => k in obj && obj[k] === mustBePresent[k])
+
+/**
+ * Check that a subset of properties with their values are present.
+ * Useful for working with Redux actions, or variants in general.
+ *
+ * @param {object} mustBePresent
+ */
+export const has = (mustBePresent) => prism(
+  (obj)         => checkPresence(mustBePresent, obj) ? obj : notFound,
+  (newObj, obj) => checkPresence(mustBePresent, obj) ? newObj : obj,
+  (newObj)      => newObj
+)

--- a/src/Prism.js
+++ b/src/Prism.js
@@ -56,7 +56,7 @@ const checkPresence = (mustBePresent, obj) =>
  * @param {object} mustBePresent
  */
 export const has = (mustBePresent) => prism(
-  (obj)         => checkPresence(mustBePresent, obj) ? obj : notFound,
-  (newObj, obj) => checkPresence(mustBePresent, obj) ? newObj : obj,
-  (newObj)      => newObj
+  (obj)         => checkPresence(mustBePresent, obj) ? {...obj} : notFound,
+  (newObj, obj) => checkPresence(mustBePresent, obj) ? {...newObj} : {...obj},
+  (newObj)      => { return { ...newObj, ...mustBePresent } }
 )

--- a/src/Prism.js
+++ b/src/Prism.js
@@ -1,5 +1,6 @@
+import { curry } from './functions'
+import { isNotFound } from './notFound'
 import { setter } from './Setter'
-import { curry, isNil } from './functions'
 import { optional } from './Optional'
 import { reviewer } from './Reviewer'
 import { partialGetter } from './PartialGetter'
@@ -13,7 +14,7 @@ class Prism {
 
   over = (f, obj) => {
     const v = this.preview(obj)
-    return isNil(v) ? obj : this.set(f(v), obj)
+    return isNotFound(v) ? obj : this.set(f(v), obj)
   }
 
   // setter = over + set

--- a/src/functions.js
+++ b/src/functions.js
@@ -27,6 +27,3 @@ export const set = curry((key, val, obj) => (key in obj ? { ...obj, [key]: val }
 
 // toUpper : String -> String
 export const toUpper = (str) => str.toUpperCase()
-
-// isNil : Nullable a => a -> Boolean
-export const isNil = (x) => x === null || x === undefined

--- a/src/notFound.js
+++ b/src/notFound.js
@@ -1,0 +1,6 @@
+/**
+ * The special value for 'not found'
+ */
+export const notFound = Symbol('notFound')
+
+export const isNotFound = (x) => x === notFound


### PR DESCRIPTION
(Either this of #7 should be rebased in top of the other before merging)

After many discussions about whether to use `null` or `undefined`, I finally saw the light: [`Symbol`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) 🌟 

MDN explains that:

> A symbol value may be used [...] as an implementation-supported unique identifier in general

Exactly what we need to differentiate non-existing values in optionals from any other value!