### PR TITLE
feat(optics): new alter lens to add or remove properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ npm install optics.js --save
 
 If you want to know more about the implementation, you can check this talk by [myself](https://twitter.com/FlavioCorpa) at [Lambda World](https://cadiz.lambda.world/).
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/IoVaArsh6tM" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[![lw](https://img.youtube.com/vi/IoVaArsh6tM/0.jpg)](https://www.youtube.com/watch?v=IoVaArsh6tM)
 
 ## Meet it!
 
@@ -71,7 +71,7 @@ const agePlus1Traversal = o.over((x) => x + 1, people)
 
 Optics provide a _language_ for data _access_ and _manipulation_ in a concise and compositional way. It excels when you want to code in an _immutable_ way.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/tbNi-ykYev8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[![intro](https://img.youtube.com/vi/tbNi-ykYev8/0.jpg)](https://www.youtube.com/watch?v=tbNi-ykYev8)
 
 There are very few moving parts in `optics.js`, the power comes from the ability to create long combinations or _paths_ by composing small primitive optics. Let's look at an example:
 
@@ -135,7 +135,7 @@ The previous six kinds of optics can only access or modify values. There is one 
 ```js
 import { review, single } from 'optics.js'
 
-review(single('say'), 'hi!')  // > { say: 'hi!' }
+review(single('say'), 'hi!') // > { say: 'hi!' }
 ```
 
 This adds yet another axis to our previous table, depending on whether when accessing you are guaranteed to have a value or not.

--- a/__tests__/Iso.test.js
+++ b/__tests__/Iso.test.js
@@ -1,4 +1,5 @@
-import { iso } from '../src/Iso'
+import { iso, single } from '../src/Iso'
+import { view, review } from '../src/operations'
 
 const id = (x) => x
 const idIso = iso(id, id)
@@ -20,11 +21,19 @@ describe('Iso', () => {
   })
 
   optics.forEach((optic) => {
-    test(optic, () => {
+    test('conversion to ' + optic, () => {
       const nm = `as${optic}`
       const o = idIso[nm]
       expect(o[nm]).toBe(o)
       expect(o.constructor.name).toBe(optic)
     })
+  })
+
+  test('single obtains value', () => {
+    expect(view(single('name'), { name: 'Alex' })).toBe('Alex')
+  })
+
+  test('single obtains value', () => {
+    expect(review(single('name'), 'Alex')).toStrictEqual({ name: 'Alex' })
   })
 })

--- a/__tests__/Lens.test.js
+++ b/__tests__/Lens.test.js
@@ -1,5 +1,6 @@
 import { get, set as assoc, toUpper } from '../src/functions'
-import { ix, lens, prop } from '../src/Lens'
+import { alter, ix, lens, prop } from '../src/Lens'
+import { notFound } from '../src/notFound'
 import { optic, over, preview, set, toArray, view } from '../src/operations'
 
 const friends = ['Alejandro']
@@ -49,6 +50,31 @@ describe('Lens', () => {
 
     expect(view(firstFriendL, userWithFriends)).toBe('Alejandro')
     expect(preview(firstFriendL, userWithFriends)).toBe('Alejandro')
+  })
+
+  test('alter should build a lens', () => {
+    const nameL = alter('name')
+    expect(view(nameL, user)).toBe('Flavio')
+  })
+
+  test('over should lift a function over an alter lens', () => {
+    const nameL = alter('name')
+    expect(over(nameL, toUpper, user)).toEqual({ id: 1, name: 'FLAVIO' })
+  })
+
+  test('set over alter should create a property', () => {
+    const nameL = alter('flip')
+    expect(set(nameL, 'flop', user)).toEqual({ ...user, flip: 'flop' })
+  })
+
+  test('alter should return not found', () => {
+    const nameL = optic(alter('flip'), alter('mix'))
+    expect(view(nameL, {})).toEqual(notFound)
+  })
+
+  test('set over alter at two level', () => {
+    const nameL = optic(alter('flip'), alter('mix'))
+    expect(set(nameL, 'flop', {})).toEqual({ flip: { mix: 'flop' } })
   })
 
   test('Lens.asOptional -> should convert to an Optional correctly', () => {

--- a/__tests__/Lens.test.js
+++ b/__tests__/Lens.test.js
@@ -77,6 +77,11 @@ describe('Lens', () => {
     expect(set(nameL, 'flop', {})).toEqual({ flip: { mix: 'flop' } })
   })
 
+  test('over over alter at two level', () => {
+    const nameL = optic(alter('flip'), alter('mix'))
+    expect(over(nameL, () => 1, {})).toEqual({ flip: { mix: 1 } })
+  })
+
   test('Lens.asOptional -> should convert to an Optional correctly', () => {
     const ageOptional = prop('age').asOptional
     expect(preview(ageOptional, user)).toBeUndefined()

--- a/__tests__/Optional.test.js
+++ b/__tests__/Optional.test.js
@@ -1,8 +1,8 @@
 import { get, set as assoc, toUpper } from '../src/functions'
 import { prop } from '../src/Lens'
 import { notFound } from '../src/notFound'
-import { maybe, optic, over, preview, set } from '../src/operations'
-import { optional, optionalIx, optionalProp } from '../src/Optional'
+import { optic, over, preview, set } from '../src/operations'
+import { maybe, optional, optionalIx, optionalProp } from '../src/Optional'
 
 const friends = ['Alejandro']
 const user = { id: 1, name: 'Flavio' }

--- a/__tests__/Optional.test.js
+++ b/__tests__/Optional.test.js
@@ -1,5 +1,6 @@
+import { OpticCreationError } from '../src/errors'
 import { get, set as assoc, toUpper } from '../src/functions'
-import { prop } from '../src/Lens'
+import { alter } from '../src/Lens'
 import { notFound } from '../src/notFound'
 import { optic, over, preview, set } from '../src/operations'
 import { maybe, optional, optionalIx, optionalProp } from '../src/Optional'
@@ -18,61 +19,53 @@ describe('Optional', () => {
     expect(set(lense, 'Alejandro', user)).toEqual({ id: 1, name: 'Alejandro' })
   })
 
-  test('optionalProp should build a lens', () => {
+  test('optionalProp should build an optional', () => {
     const nameL = optionalProp('name')
-
     expect(preview(nameL, user)).toBe('Flavio')
   })
 
-  test('optionalIndex should build a lens', () => {
+  test('optionalIndex should build an optional', () => {
     const idx0 = optionalIx(0)
-
     expect(preview(idx0, friends)).toBe('Alejandro')
+    expect(set(idx0, 'Alex', friends)).toStrictEqual(['Alex'])
   })
 
-  test('over should lift a function over a Lens', () => {
+  test('over should lift a function over an optional', () => {
     const nameL = optionalProp('name')
-
     expect(over(nameL, toUpper, user)).toEqual({ id: 1, name: 'FLAVIO' })
   })
 
   test('optionals should compose', () => {
     const firstFriendL = optic(optionalProp('friends'), optionalIx(0))
-
     expect(preview(firstFriendL, userWithFriends)).toBe('Alejandro')
   })
 
   test('optionals should be created by optic', () => {
     const firstFriendL = optic(maybe('friends'), maybe(0))
-
     expect(preview(firstFriendL, userWithFriends)).toBe('Alejandro')
   })
 
   test('optionals should be created by optic', () => {
-    const firstFriendL = optic(maybe(prop('friends')), maybe(0))
-
+    const firstFriendL = optic(maybe(alter('friends')), maybe(0))
     expect(preview(firstFriendL, userWithFriends)).toBe('Alejandro')
   })
 
   test('optionals with non-existing key should return notFound', () => {
     const serventesioL = optionalProp('serventesio')
-
     expect(preview(serventesioL, user)).toBe(notFound)
   })
 
   test('optionals with non-existing key should not change the value', () => {
     const serventesioL = optionalProp('serventesio')
-
     expect(over(serventesioL, toUpper, user)).toEqual(user)
   })
 
   test('optionals with one non-existing key should return notFound', () => {
     const firstFriendL = optic(optionalProp('friends'), optionalIx(1000))
-
     expect(preview(firstFriendL, userWithFriends)).toBe(notFound)
   })
 
   test('maybe should fail for wrong types', () => {
-    expect(maybe([1, 2])).toBe(undefined)
+    expect(() => maybe([1, 2])).toThrow(OpticCreationError)
   })
 })

--- a/__tests__/Prism.test.js
+++ b/__tests__/Prism.test.js
@@ -4,6 +4,8 @@ import { optic, over, preview, review, toArray } from '../src/operations'
 import { has } from '../src/Prism'
 
 const user = { id: 1, name: 'Flavio' }
+const modifiedUser = { id: 1, name: 'Alejandro' }
+const modifyUser = (u) => ({ ...u, name: 'Alejandro' })
 
 describe('Prism', () => {
   test('has returns itself if ok', () => {
@@ -14,8 +16,20 @@ describe('Prism', () => {
     expect(preview(has({ id: 2 }), user)).toEqual(notFound)
   })
 
+  test('has works correctly when setting', () => {
+    expect(over(has({ id: 1 }), modifyUser, user)).toStrictEqual(modifiedUser)
+    expect(has({ id: 1 }).over(modifyUser, user)).toStrictEqual(modifiedUser)
+  })
+
   test('has works correctly in composition with lens', () => {
-    expect(over(optic(has({ id: 1 }), 'name'), toUpper, user)).toEqual({ id: 1, name: 'FLAVIO' })
+    expect(over(optic(has({ id: 1 }), 'name'), toUpper, user)).toStrictEqual({
+      id: 1,
+      name: 'FLAVIO',
+    })
+    expect(optic(has({ id: 1 }), 'name').over(toUpper, user)).toStrictEqual({
+      id: 1,
+      name: 'FLAVIO',
+    })
   })
 
   test('has works correctly in composition', () => {
@@ -27,15 +41,13 @@ describe('Prism', () => {
     })
   })
 
-  test('Prism.asTraversal -> should convert to an Optional correctly', () => {
-    expect(toArray(optic(has({ id: 1 }), 'name'), user)).toEqual(['Flavio'])
-  })
-
   test('Prism.asTraversal -> works when value is found', () => {
+    expect(toArray(has({ id: 1 }), user)).toEqual([user])
     expect(toArray(optic(has({ id: 1 }), 'name'), user)).toEqual(['Flavio'])
   })
 
   test('Prism.asTraversal -> works when value is not found', () => {
+    expect(toArray(has({ id: 2 }), user)).toEqual([])
     expect(toArray(optic(has({ id: 2 }), 'name'), user)).toEqual([])
   })
 })

--- a/__tests__/Traversal.test.js
+++ b/__tests__/Traversal.test.js
@@ -1,10 +1,14 @@
 import { optic, over, reduce, toArray } from '../src/operations'
-import { values } from '../src/Traversal'
+import { entries, values } from '../src/Traversal'
 
 const doubleArray = [
   [1, 2],
   [3, 4],
 ]
+const exampleObject = {
+  one: 1,
+  two: 2,
+}
 
 describe('Traversal', () => {
   test('traversal from array reduces', () => {
@@ -31,5 +35,23 @@ describe('Traversal', () => {
       [2, 3],
       [4, 5],
     ])
+  })
+
+  test('traversal from entries reduces', () => {
+    expect(reduce(entries, (x, [_, y]) => x + y, 0, exampleObject)).toBe(3)
+  })
+
+  test('traversal from entries turns into array', () => {
+    expect(toArray(entries, exampleObject)).toStrictEqual([
+      ['one', 1],
+      ['two', 2],
+    ])
+  })
+
+  test('traversal from entries modified', () => {
+    expect(over(entries, ([k, v]) => [k, v + 1], exampleObject)).toStrictEqual({
+      one: 2,
+      two: 3,
+    })
   })
 })

--- a/__tests__/operations.test.js
+++ b/__tests__/operations.test.js
@@ -1,7 +1,7 @@
 import { OpticComposeError, UnavailableOpticOperationError } from '../src/errors'
 import { toUpper } from '../src/functions'
 import { getter } from '../src/Getter'
-import { prop } from '../src/Lens'
+import { alter } from '../src/Lens'
 import { optic, over, path, set, view } from '../src/operations'
 import { setter } from '../src/Setter'
 
@@ -41,7 +41,12 @@ describe('Operations over Optics', () => {
   })
 
   test('path should create the same lense as a manually defined one', () => {
-    const hardLense = optic(prop('styles'), prop('CodeSurfer'), prop('code'), prop('fontFamily'))
+    const hardLense = optic(
+      alter('styles'),
+      alter('CodeSurfer'),
+      alter('code'),
+      alter('fontFamily'),
+    )
 
     expect(view(hardLense, theme)).toBe(view(fontLense, theme))
   })
@@ -50,6 +55,12 @@ describe('Operations over Optics', () => {
     const hardLense = optic('styles', 'CodeSurfer', 'code', 'fontFamily')
 
     expect(view(hardLense, theme)).toBe(view(fontLense, theme))
+  })
+
+  test('path short-hand and setting creates values', () => {
+    const hardLense = optic('styles', 'CodeSurfer', 'code', 'fontFamily')
+
+    expect(set(hardLense, 'monospaced', {})).toStrictEqual(theme)
   })
 
   test('incompatible optics', () => {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+export * from './src/errors'
 export * from './src/Fold'
 export * from './src/functions'
 export * from './src/Getter'

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   },
   "files": [
     "dist",
-    "index.js",
     "src"
   ],
   "scripts": {
@@ -96,10 +95,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "branches": 78,
-        "functions": 76,
-        "lines": 87,
-        "statements": 81
+        "branches": 80,
+        "functions": 83,
+        "lines": 91,
+        "statements": 85
       }
     },
     "testEnvironment": "node"

--- a/src/Iso.js
+++ b/src/Iso.js
@@ -75,3 +75,10 @@ class Iso {
 
 // iso : (s → a) → (a → s) → Iso s a
 export const iso = curry((get, review) => new Iso(get, review))
+
+// singleton : Key -> Iso { k: a } a
+export const single = (key) =>
+  iso(
+    (obj) => obj[key],
+    (val) => ({ [key]: val }),
+  )

--- a/src/Lens.js
+++ b/src/Lens.js
@@ -70,11 +70,9 @@ export const alter = (key) =>
     (obj) => (isNotFound(obj) ? notFound : obj[key] || notFound),
     (val, obj) => {
       if (isNotFound(val)) {
-        // https://stackoverflow.com/a/33053362/1236540
-        /* eslint-disable no-unused-vars */
-        let { [key]: omit, ...newObj } = obj
+        // eslint-disable-next-line no-unused-vars
+        const { [key]: _, ...newObj } = obj
         return newObj
-        /* eslint-enable no-unused-vars */
       } else {
         return { ...obj, [key]: val }
       }

--- a/src/Lens.js
+++ b/src/Lens.js
@@ -1,5 +1,5 @@
 import { fold } from './Fold'
-import { curry, get, set } from './functions'
+import { curry, get, set, setIndex } from './functions'
 import { getter } from './Getter'
 import { isNotFound, notFound } from './notFound'
 import { optional } from './Optional'
@@ -58,11 +58,11 @@ class Lens {
 // lens : (s → a) → ((a, s) → s) → Lens s a
 export const lens = curry((get, set) => new Lens(get, set))
 
-// prop : String → Lens s a
-export const prop = (key) => lens(get(key), set(key))
-
 // ix : Number → Lens s a
-export const ix = (index) => lens(get(index), set(index))
+export const ix = (index) => lens(get(index), setIndex(index))
+
+// mustBePresent : String → Lens s a
+export const mustBePresent = (key) => lens(get(key), set(key))
 
 // alter : String → Lens (Maybe s) (Maybe a)
 export const alter = (key) =>

--- a/src/Lens.js
+++ b/src/Lens.js
@@ -1,6 +1,7 @@
 import { fold } from './Fold'
 import { curry, get, set } from './functions'
 import { getter } from './Getter'
+import { isNotFound, notFound } from './notFound'
 import { optional } from './Optional'
 import { partialGetter } from './PartialGetter'
 import { setter } from './Setter'
@@ -62,3 +63,18 @@ export const prop = (key) => lens(get(key), set(key))
 
 // ix : Number → Lens s a
 export const ix = (index) => lens(get(index), set(index))
+
+// alter : String → Lens (Maybe s) (Maybe a)
+export const alter = (key) =>
+  lens(
+    (obj) => (isNotFound(obj) ? notFound : obj[key] || notFound),
+    (val, obj) => {
+      if (isNotFound(val)) {
+        var newObj = { ...obj }
+        delete newObj[key]
+        return newObj
+      } else {
+        return { ...obj, [key]: val }
+      }
+    },
+  )

--- a/src/Lens.js
+++ b/src/Lens.js
@@ -70,9 +70,11 @@ export const alter = (key) =>
     (obj) => (isNotFound(obj) ? notFound : obj[key] || notFound),
     (val, obj) => {
       if (isNotFound(val)) {
-        var newObj = { ...obj }
-        delete newObj[key]
+        // https://stackoverflow.com/a/33053362/1236540
+        /* eslint-disable no-unused-vars */
+        let { [key]: omit, ...newObj } = obj
         return newObj
+        /* eslint-enable no-unused-vars */
       } else {
         return { ...obj, [key]: val }
       }

--- a/src/Optional.js
+++ b/src/Optional.js
@@ -64,3 +64,18 @@ export const optionalIx = (index) =>
     (obj) => obj[index] || notFound,
     (val, obj) => (obj[index] ? { ...obj, [index]: val } : obj),
   )
+
+// maybe : (String | Int | Lens s a) -> Optional s a
+export const maybe = (optic) => {
+  if (typeof optic == 'string' || optic instanceof String) {
+    return optionalProp(optic)
+  }
+  if (typeof optic == 'number' && !isNaN(optic)) {
+    return optionalIx(optic)
+  }
+  if (optic.asLens) {
+    const l = optic.asLens
+    return optional(l.get, l.set)
+  }
+  return undefined
+}

--- a/src/Optional.js
+++ b/src/Optional.js
@@ -1,5 +1,6 @@
+import { OpticCreationError } from './errors'
 import { fold } from './Fold'
-import { curry } from './functions'
+import { curry, setIndex } from './functions'
 import { isNotFound, notFound, notFoundToList } from './notFound'
 import { partialGetter } from './PartialGetter'
 import { setter } from './Setter'
@@ -62,7 +63,7 @@ export const optionalProp = (key) =>
 export const optionalIx = (index) =>
   optional(
     (obj) => obj[index] || notFound,
-    (val, obj) => (obj[index] ? { ...obj, [index]: val } : obj),
+    (val, obj) => (obj[index] ? setIndex(index, val, obj) : obj),
   )
 
 // maybe : (String | Int | Lens s a) -> Optional s a
@@ -77,5 +78,5 @@ export const maybe = (optic) => {
     const l = optic.asLens
     return optional(l.get, l.set)
   }
-  return undefined
+  throw new OpticCreationError('Optional', typeof optic + ' cannot be turned into optional')
 }

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,6 +1,22 @@
 // define error classes as instructed in
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
 
+export class OpticCreationError extends Error {
+  constructor(optic, ...params) {
+    // Pass remaining arguments (including vendor specific ones) to parent constructor
+    super(...params)
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, OpticComposeError)
+    }
+
+    this.name = 'OpticCreationError'
+    // Custom debugging information
+    this.optic = optic
+  }
+}
+
 export class OpticComposeError extends Error {
   constructor(optic1, optic2, ...params) {
     // Pass remaining arguments (including vendor specific ones) to parent constructor

--- a/src/functions.js
+++ b/src/functions.js
@@ -25,5 +25,8 @@ export const get = curry((key, obj) => obj[key])
 // set : String -> a -> {k: v} -> {k: v}
 export const set = curry((key, val, obj) => (obj[key] ? { ...obj, [key]: val } : obj))
 
+// setIndex : Index -> a -> [a] -> [a]
+export const setIndex = curry((index, val, array) => array.map((v, i) => (i == index ? val : v)))
+
 // toUpper : String -> String
 export const toUpper = (str) => str.toUpperCase()

--- a/src/operations.js
+++ b/src/operations.js
@@ -2,7 +2,7 @@ import { OpticComposeError, UnavailableOpticOperationError } from './errors'
 import { fold } from './Fold'
 import { curry } from './functions'
 import { getter } from './Getter'
-import { ix, lens, prop } from './Lens'
+import { alter, ix, lens } from './Lens'
 import { isNotFound, notFound } from './notFound'
 import { optional } from './Optional'
 import { partialGetter } from './PartialGetter'
@@ -92,7 +92,7 @@ const compose2Optics = (optic1, optic2) => {
 
 const toOptic = (optic) => {
   if (typeof optic == 'string' || optic instanceof String) {
-    return prop(optic)
+    return alter(optic)
   }
   if (typeof optic == 'number' && !isNaN(optic)) {
     return ix(optic)

--- a/src/operations.js
+++ b/src/operations.js
@@ -4,7 +4,7 @@ import { curry } from './functions'
 import { getter } from './Getter'
 import { ix, lens, prop } from './Lens'
 import { isNotFound, notFound } from './notFound'
-import { optional, optionalIx, optionalProp } from './Optional'
+import { optional } from './Optional'
 import { partialGetter } from './PartialGetter'
 import { prism } from './Prism'
 import { reviewer } from './Reviewer'
@@ -203,18 +203,3 @@ export const review = curry((optic, obj) => {
       'review is not supported by ' + optic.constructor.name,
     )
 })
-
-// maybe : (String | Int | Lens s a) -> Optional s a
-export const maybe = (optic) => {
-  if (typeof optic == 'string' || optic instanceof String) {
-    return optionalProp(optic)
-  }
-  if (typeof optic == 'number' && !isNaN(optic)) {
-    return optionalIx(optic)
-  }
-  if (optic.asLens) {
-    const l = optic.asLens
-    return optional(l.get, l.set)
-  }
-  return undefined
-}


### PR DESCRIPTION
Following the advice we got from internet, I've implemented an `alter` optic which works like the `at` in Haskell, that is, a lens to a `Maybe` which can add or remove properties. To make it composable I actually make it work over `Maybe s`, where `Maybe` is simply adding `notFound` as a possible input.

```haskell
alter : Key -> Lens (Maybe s) (Maybe a)
```

So now you have that:

```js
const nameL = optic(alter('flip'), alter('mix'))
expect(set(nameL, 'flop', {})).toEqual({ flip: { mix: 'flop' } })
```

We can always make `alter` the actual default to get the behavior we see in Ramda. Of course, that means that properties and indices in an array no longer work the same, as for the latter we cannot play this trick.