### PR TITLE
New combinators

### DIFF
--- a/__tests__/Fold.test.js
+++ b/__tests__/Fold.test.js
@@ -33,10 +33,8 @@ describe('Traversal', () => {
     expect(reduce(o, (x, y) => x + y, 0, doubleArray)).toBe(10)
   })
 
-  /*
   test('traversal from double reduce turns into array', () => {
     const o = optic(valuesReduceFold, valuesReduceFold)
     expect(toArray(o, doubleArray)).toStrictEqual(doubleArray.flat())
   })
-  */
 })

--- a/__tests__/Fold.test.js
+++ b/__tests__/Fold.test.js
@@ -33,8 +33,10 @@ describe('Traversal', () => {
     expect(reduce(o, (x, y) => x + y, 0, doubleArray)).toBe(10)
   })
 
+  /*
   test('traversal from double reduce turns into array', () => {
     const o = optic(valuesReduceFold, valuesReduceFold)
     expect(toArray(o, doubleArray)).toStrictEqual(doubleArray.flat())
   })
+  */
 })

--- a/__tests__/Fold.test.js
+++ b/__tests__/Fold.test.js
@@ -1,4 +1,4 @@
-import { foldFromToArray } from '../src/Fold'
+import { foldFromReduce, foldFromToArray } from '../src/Fold'
 import { optic, reduce, toArray } from '../src/operations'
 
 const doubleArray = [
@@ -7,6 +7,7 @@ const doubleArray = [
 ]
 
 const valuesFold = foldFromToArray((obj) => [...obj])
+const valuesReduceFold = foldFromReduce((f, i, obj) => obj.reduce(f, i))
 
 describe('Traversal', () => {
   test('traversal from array reduces', () => {
@@ -18,8 +19,22 @@ describe('Traversal', () => {
     expect(reduce(o, (x, y) => x + y, 0, doubleArray)).toBe(10)
   })
 
-  test('traversal from double array reduces', () => {
+  test('traversal from double array turns into array', () => {
     const o = optic(valuesFold, valuesFold)
+    expect(toArray(o, doubleArray)).toStrictEqual(doubleArray.flat())
+  })
+
+  test('traversal from reduce reduces', () => {
+    expect(reduce(valuesReduceFold, (x, y) => x + y, 0, [1, 2])).toBe(3)
+  })
+
+  test('traversal from double reduce reduces', () => {
+    const o = optic(valuesReduceFold, valuesReduceFold)
+    expect(reduce(o, (x, y) => x + y, 0, doubleArray)).toBe(10)
+  })
+
+  test('traversal from double reduce turns into array', () => {
+    const o = optic(valuesReduceFold, valuesReduceFold)
     expect(toArray(o, doubleArray)).toStrictEqual(doubleArray.flat())
   })
 })

--- a/__tests__/Getter.test.js
+++ b/__tests__/Getter.test.js
@@ -1,6 +1,6 @@
 import { get } from '../src/functions'
-import { getter } from '../src/Getter'
-import { preview, toArray } from '../src/operations'
+import { always, getter } from '../src/Getter'
+import { preview, toArray, view } from '../src/operations'
 
 const obj = {
   foo: [1, 2, 3],
@@ -22,5 +22,9 @@ describe('Getter', () => {
     expect(preview(partial, obj)).toBe('baz')
     expect(toArray(partial, obj)).toEqual(['baz'])
     expect(partial.toArray(obj)).toEqual(['baz'])
+  })
+
+  test('always works as expected', () => {
+    expect(view(always('foo'), obj)).toBe('foo')
   })
 })

--- a/__tests__/Iso.test.js
+++ b/__tests__/Iso.test.js
@@ -1,7 +1,17 @@
 import { UnavailableOpticOperationError } from '../src/errors'
 import { toUpper } from '../src/functions'
 import { iso, single } from '../src/Iso'
-import { optic, over, preview, reduce, review, set, toArray, view } from '../src/operations'
+import {
+  matches,
+  optic,
+  over,
+  preview,
+  reduce,
+  review,
+  set,
+  toArray,
+  view,
+} from '../src/operations'
 
 const id = (x) => x
 const idIso = iso(id, id)
@@ -60,6 +70,8 @@ describe('Iso', () => {
       expect(toArray(o, { name: 'Alex' })).toStrictEqual(['Alex'])
       expect(o.toArray({ name: 'Alex' })).toStrictEqual(['Alex'])
       expect(reduce(o, (x, y) => x + y, 1, { name: 2 })).toBe(3)
+      expect(matches(o, { name: 'Alex' })).toBe(true)
+      expect(o.matches({ name: 'Alex' })).toBe(true)
 
       if (gopt === 'Fold') {
         expect(() => preview(o, { name: 'Alex' })).toThrow(UnavailableOpticOperationError)
@@ -100,6 +112,7 @@ describe('Iso', () => {
         expect(() => toArray(o, { name: 'Alex' })).toThrow(UnavailableOpticOperationError)
         expect(() => set(o, 'Flavio', { name: 'Alex' })).toThrow(UnavailableOpticOperationError)
         expect(() => over(o, toUpper, { name: 'Alex' })).toThrow(UnavailableOpticOperationError)
+        expect(() => matches(o, { name: 'Alex' })).toThrow(UnavailableOpticOperationError)
       }
     })
   })

--- a/__tests__/Lens.test.js
+++ b/__tests__/Lens.test.js
@@ -1,7 +1,7 @@
 import { get, set as assoc, toUpper } from '../src/functions'
 import { alter, ix, lens, mustBePresent } from '../src/Lens'
 import { notFound } from '../src/notFound'
-import { optic, over, preview, set, toArray, view } from '../src/operations'
+import { matches, optic, over, preview, sequence, set, toArray, view } from '../src/operations'
 
 const friends = ['Alejandro', 'Pepe']
 const user = { id: 1, name: 'Flavio' }
@@ -18,6 +18,7 @@ describe('Lens', () => {
     expect(lense.get(user)).toBe('Flavio')
     expect(preview(lense, user)).toBe('Flavio')
     expect(set(lense, 'Alejandro', user)).toEqual(alex)
+    expect(matches(lense, user)).toBe(true)
   })
 
   test('mustBePresent should build a lens', () => {
@@ -150,5 +151,9 @@ describe('Lens', () => {
     const nameOptional = mustBePresent('name').asFold
     expect(toArray(nameOptional, user)).toEqual(['Flavio'])
     expect(nameOptional.toArray(user)).toEqual(['Flavio'])
+  })
+
+  test('should sequence lenses correctly', () => {
+    expect(toArray(sequence('id', 'name'), user)).toEqual([1, 'Flavio'])
   })
 })

--- a/__tests__/Optional.test.js
+++ b/__tests__/Optional.test.js
@@ -2,7 +2,7 @@ import { OpticCreationError } from '../src/errors'
 import { get, set as assoc, toUpper } from '../src/functions'
 import { alter } from '../src/Lens'
 import { notFound } from '../src/notFound'
-import { matches, optic, over, preview, set, toArray } from '../src/operations'
+import { firstOf, matches, optic, over, preview, set, toArray } from '../src/operations'
 import { maybe, never, optional, optionalIx, optionalProp } from '../src/Optional'
 
 const friends = ['Alejandro']
@@ -99,5 +99,11 @@ describe('Optional', () => {
     expect(never.set('A', user)).toStrictEqual(user)
     expect(set(never, 'A', [1, 2])).toStrictEqual([1, 2])
     expect(never.set('A', [1, 2])).toStrictEqual([1, 2])
+  })
+
+  test('first of works', () => {
+    expect(preview(firstOf('name', 'toli'), user)).toBe('Flavio')
+    expect(preview(firstOf('toli', 'name'), user)).toBe('Flavio')
+    expect(preview(firstOf('toli', 'moli'), user)).toBe(notFound)
   })
 })

--- a/__tests__/Optional.test.js
+++ b/__tests__/Optional.test.js
@@ -101,9 +101,19 @@ describe('Optional', () => {
     expect(never.set('A', [1, 2])).toStrictEqual([1, 2])
   })
 
-  test('first of works', () => {
+  test('first of works for viewing', () => {
     expect(preview(firstOf('name', 'toli'), user)).toBe('Flavio')
     expect(preview(firstOf('toli', 'name'), user)).toBe('Flavio')
+    expect(preview(firstOf('name', 'id'), user)).toBe('Flavio')
+    expect(preview(firstOf('id', 'name'), user)).toBe(1)
     expect(preview(firstOf('toli', 'moli'), user)).toBe(notFound)
+  })
+
+  test('first of works for setting', () => {
+    expect(over(firstOf('name', 'toli'), toUpper, user)).toStrictEqual({ id: 1, name: 'FLAVIO' })
+    expect(over(firstOf('toli', 'name'), toUpper, user)).toStrictEqual({ id: 1, name: 'FLAVIO' })
+    expect(over(firstOf('name', 'id'), toUpper, user)).toStrictEqual({ id: 1, name: 'FLAVIO' })
+    expect(over(firstOf('id', 'name'), (x) => x + 1, user)).toStrictEqual({ id: 2, name: 'Flavio' })
+    expect(over(firstOf('toli', 'moli'), toUpper, user)).toStrictEqual(user)
   })
 })

--- a/__tests__/Optional.test.js
+++ b/__tests__/Optional.test.js
@@ -2,8 +2,8 @@ import { OpticCreationError } from '../src/errors'
 import { get, set as assoc, toUpper } from '../src/functions'
 import { alter } from '../src/Lens'
 import { notFound } from '../src/notFound'
-import { optic, over, preview, set, toArray } from '../src/operations'
-import { maybe, optional, optionalIx, optionalProp } from '../src/Optional'
+import { matches, optic, over, preview, set, toArray } from '../src/operations'
+import { maybe, never, optional, optionalIx, optionalProp } from '../src/Optional'
 
 const friends = ['Alejandro']
 const user = { id: 1, name: 'Flavio' }
@@ -22,6 +22,7 @@ describe('Optional', () => {
   test('optionalProp should build an optional', () => {
     const nameL = optionalProp('name')
     expect(preview(nameL, user)).toBe('Flavio')
+    expect(matches(nameL, user)).toBe(true)
   })
 
   test('optionalProp should works as a traversal', () => {
@@ -33,6 +34,7 @@ describe('Optional', () => {
   test('optionalIndex should build an optional', () => {
     const idx0 = optionalIx(0)
     expect(preview(idx0, friends)).toBe('Alejandro')
+    expect(matches(idx0, friends)).toBe(true)
     expect(set(idx0, 'Alex', friends)).toStrictEqual(['Alex'])
   })
 
@@ -58,13 +60,17 @@ describe('Optional', () => {
 
   test('optionals with non-existing key should return notFound', () => {
     const serventesioL = optionalProp('serventesio')
+    expect(set(serventesioL, 'Pi', user)).toStrictEqual(user)
+    expect(serventesioL.set('Pi', user)).toStrictEqual(user)
     expect(preview(serventesioL, user)).toBe(notFound)
+    expect(matches(serventesioL, user)).toBe(false)
   })
 
   test('optionals with non-existing as traversal should return []', () => {
     const serventesioL = optionalProp('serventesio')
     expect(toArray(serventesioL, user)).toStrictEqual([])
     expect(toArray(serventesioL.asTraversal, user)).toStrictEqual([])
+    expect(matches(serventesioL.asTraversal, user)).toBe(false)
   })
 
   test('optionals with non-existing key should not change the value', () => {
@@ -74,10 +80,24 @@ describe('Optional', () => {
 
   test('optionals with one non-existing key should return notFound', () => {
     const firstFriendL = optic(optionalProp('friends'), optionalIx(1000))
+    expect(set(firstFriendL, 'Pi', userWithFriends)).toStrictEqual(userWithFriends)
+    expect(firstFriendL.set('Pi', userWithFriends)).toStrictEqual(userWithFriends)
     expect(preview(firstFriendL, userWithFriends)).toBe(notFound)
+    expect(matches(firstFriendL, userWithFriends)).toBe(false)
   })
 
   test('maybe should fail for wrong types', () => {
     expect(() => maybe([1, 2])).toThrow(OpticCreationError)
+  })
+
+  test('never should always return notFound', () => {
+    expect(matches(never, user)).toBe(false)
+    expect(never.matches(user)).toBe(false)
+    expect(matches(never, [1, 2])).toBe(false)
+
+    expect(set(never, 'A', user)).toStrictEqual(user)
+    expect(never.set('A', user)).toStrictEqual(user)
+    expect(set(never, 'A', [1, 2])).toStrictEqual([1, 2])
+    expect(never.set('A', [1, 2])).toStrictEqual([1, 2])
   })
 })

--- a/__tests__/Prism.test.js
+++ b/__tests__/Prism.test.js
@@ -1,6 +1,7 @@
+import { OpticComposeError, UnavailableOpticOperationError } from '../src/errors'
 import { toUpper } from '../src/functions'
 import { notFound } from '../src/notFound'
-import { optic, over, preview, review, toArray } from '../src/operations'
+import { matches, optic, over, preview, review, sequence, toArray } from '../src/operations'
 import { has } from '../src/Prism'
 
 const user = { id: 1, name: 'Flavio' }
@@ -10,10 +11,14 @@ const modifyUser = (u) => ({ ...u, name: 'Alejandro' })
 describe('Prism', () => {
   test('has returns itself if ok', () => {
     expect(preview(has({ id: 1 }), user)).toEqual(user)
+    expect(matches(has({ id: 1 }), user)).toBe(true)
+    expect(() => matches(has({ id: 1 }).asReviewer, user)).toThrow(UnavailableOpticOperationError)
+    expect(() => sequence(has({ id: 1 }).asReviewer)).toThrow(OpticComposeError)
   })
 
   test('has returns nothing if not found', () => {
     expect(preview(has({ id: 2 }), user)).toEqual(notFound)
+    expect(matches(has({ id: 2 }), user)).toBe(false)
   })
 
   test('has works correctly when setting', () => {

--- a/__tests__/Prism.test.js
+++ b/__tests__/Prism.test.js
@@ -26,6 +26,16 @@ describe('Prism', () => {
     expect(has({ id: 1 }).over(modifyUser, user)).toStrictEqual(modifiedUser)
   })
 
+  test('has sets nothing if not found', () => {
+    expect(over(has({ id: 2 }), modifyUser, user)).toStrictEqual(user)
+    expect(has({ id: 2 }).over(modifyUser, user)).toStrictEqual(user)
+  })
+
+  test('has works in review', () => {
+    expect(review(has({ id: 1 }), { name: 'Flavio' })).toStrictEqual(user)
+    expect(has({ id: 1 }).review({ name: 'Flavio' })).toStrictEqual(user)
+  })
+
   test('has works correctly in composition with itself', () => {
     expect(optic(has({ id: 1 }), has({ name: 'Flavio' })).preview(user)).toStrictEqual(user)
     expect(optic(has({ id: 1 }), has({ name: 'Flavio' })).preview({ id: 2, name: 'Flavio' })).toBe(

--- a/__tests__/Traversal.test.js
+++ b/__tests__/Traversal.test.js
@@ -1,5 +1,5 @@
 import { optic, over, reduce, toArray } from '../src/operations'
-import { entries, values } from '../src/Traversal'
+import { entries, traversalFromReduce, values } from '../src/Traversal'
 
 const doubleArray = [
   [1, 2],
@@ -9,6 +9,11 @@ const exampleObject = {
   one: 1,
   two: 2,
 }
+
+const valuesReduceTraversal = traversalFromReduce(
+  (f, i, obj) => obj.reduce(f, i),
+  (f, obj) => obj.map(f),
+)
 
 describe('Traversal', () => {
   test('traversal from array reduces', () => {
@@ -37,7 +42,16 @@ describe('Traversal', () => {
     ])
   })
 
+  test('traversal from double reduce reduces', () => {
+    expect(reduce(valuesReduceTraversal, (x, y) => x + y, 0, [1, 2])).toBe(3)
+  })
+
+  test('traversal from double reduce updates', () => {
+    expect(over(valuesReduceTraversal, (x) => x + 1, [1, 2])).toStrictEqual([2, 3])
+  })
+
   test('traversal from entries reduces', () => {
+    // eslint-disable-next-line no-unused-vars
     expect(reduce(entries, (x, [_, y]) => x + y, 0, exampleObject)).toBe(3)
   })
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "release": "git-authors-cli finepack && git add package.json && standard-version -a",
     "release:tags": "git push --follow-tags origin master",
     "semantic-release": "semantic-release",
-    "test": "jest --coverage",
+    "test": "jest --coverage --silent=false",
     "test:watch": "jest --watch",
     "update": "ncu -u",
     "update:check": "ncu -- --error-level 2"

--- a/src/Fold.js
+++ b/src/Fold.js
@@ -5,7 +5,7 @@ class Fold {
     if (!reduce) this.reduce = (f, i, obj) => toArray(obj).reduce(f, i)
     else this.reduce = reduce
 
-    if (!toArray) this.toArray = (obj) => reduce((acc, cur) => acc.concat(cur), [], obj)
+    if (!toArray) this.toArray = (obj) => reduce((acc, cur) => acc.concat([cur]), [], obj)
     else this.toArray = toArray
 
     // derived operations

--- a/src/Fold.js
+++ b/src/Fold.js
@@ -7,6 +7,9 @@ class Fold {
 
     if (!toArray) this.toArray = (obj) => reduce((acc, cur) => acc.concat(cur), [], obj)
     else this.toArray = toArray
+
+    // derived operations
+    this.matches = (obj) => reduce(() => true, false, obj)
   }
 
   // itself

--- a/src/Getter.js
+++ b/src/Getter.js
@@ -10,6 +10,7 @@ class Getter {
     this.reduce = (f, i, obj) => f(i, this.get(obj))
     this.toArray = (obj) => [this.get(obj)]
     this.preview = this.get
+    this.matches = () => true
   }
 
   // fold = reduce + toArray
@@ -30,3 +31,6 @@ class Getter {
 
 // getter : (s → a) → Getter s a
 export const getter = curry((get) => new Getter(get))
+
+// always : a -> Getter s a
+export const always = curry((v) => getter(() => v))

--- a/src/Iso.js
+++ b/src/Iso.js
@@ -20,6 +20,7 @@ class Iso {
     this.reduce = (f, i, obj) => f(i, this.get(obj))
     this.toArray = (obj) => [this.get(obj)]
     this.preview = this.get
+    this.matches = () => true
   }
 
   // setter = over + set

--- a/src/Lens.js
+++ b/src/Lens.js
@@ -17,6 +17,7 @@ class Lens {
     this.reduce = (f, i, obj) => f(i, this.get(obj))
     this.toArray = (obj) => [this.get(obj)]
     this.preview = this.get
+    this.matches = () => true
   }
 
   // setter = over + set

--- a/src/Optional.js
+++ b/src/Optional.js
@@ -21,6 +21,7 @@ class Optional {
     }
     this.reduce = (f, i, obj) => notFoundToList(this.preview(obj)).reduce(f, i)
     this.toArray = (obj) => notFoundToList(this.preview(obj))
+    this.matches = (obj) => !isNotFound(preview(obj))
   }
 
   // setter = over + set
@@ -80,3 +81,9 @@ export const maybe = (optic) => {
   }
   throw new OpticCreationError('Optional', typeof optic + ' cannot be turned into optional')
 }
+
+// never : Optional s a
+export const never = optional(
+  () => notFound,
+  (_, obj) => obj,
+)

--- a/src/PartialGetter.js
+++ b/src/PartialGetter.js
@@ -1,6 +1,6 @@
 import { fold } from './Fold'
 import { curry } from './functions'
-import { notFoundToList } from './notFound'
+import { isNotFound, notFoundToList } from './notFound'
 
 /**
  * AKA: Affine Fold
@@ -12,6 +12,7 @@ class PartialGetter {
     // derived operations
     this.reduce = (f, i, obj) => notFoundToList(this.preview(obj)).reduce(f, i)
     this.toArray = (obj) => notFoundToList(this.preview(obj))
+    this.matches = (obj) => !isNotFound(preview(obj))
   }
 
   // fold = reduce + toArray

--- a/src/Prism.js
+++ b/src/Prism.js
@@ -20,6 +20,7 @@ class Prism {
     }
     this.reduce = (f, i, obj) => notFoundToList(this.preview(obj)).reduce(f, i)
     this.toArray = (obj) => notFoundToList(this.preview(obj))
+    this.matches = (obj) => !isNotFound(preview(obj))
   }
 
   // setter = over + set

--- a/src/Traversal.js
+++ b/src/Traversal.js
@@ -7,7 +7,7 @@ class Traversal {
     if (!reduce) this.reduce = (f, i, obj) => toArray(obj).reduce(f, i)
     else this.reduce = reduce
 
-    if (!toArray) this.toArray = (obj) => reduce((acc, cur) => acc.concat(cur), [], obj)
+    if (!toArray) this.toArray = (obj) => reduce((acc, cur) => acc.concat([cur]), [], obj)
     else this.toArray = toArray
 
     this.over = over

--- a/src/Traversal.js
+++ b/src/Traversal.js
@@ -14,6 +14,7 @@ class Traversal {
 
     // derived operations
     this.set = (val, x) => this.over(() => val, x)
+    this.matches = (obj) => reduce(() => true, false, obj)
   }
 
   // setter = over + set

--- a/src/errors.js
+++ b/src/errors.js
@@ -18,7 +18,7 @@ export class OpticCreationError extends Error {
 }
 
 export class OpticComposeError extends Error {
-  constructor(optic1, optic2, ...params) {
+  constructor(combinator, optics, ...params) {
     // Pass remaining arguments (including vendor specific ones) to parent constructor
     super(...params)
 
@@ -29,8 +29,8 @@ export class OpticComposeError extends Error {
 
     this.name = 'OpticComposeError'
     // Custom debugging information
-    this.optic1 = optic1
-    this.optic2 = optic2
+    this.combinator = combinator
+    this.optics = optics
   }
 }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -7,6 +7,7 @@ export class OpticCreationError extends Error {
     super(...params)
 
     // Maintains proper stack trace for where our error was thrown (only available on V8)
+    /* istanbul ignore next */
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, OpticCreationError)
     }
@@ -23,6 +24,7 @@ export class OpticComposeError extends Error {
     super(...params)
 
     // Maintains proper stack trace for where our error was thrown (only available on V8)
+    /* istanbul ignore next */
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, OpticComposeError)
     }
@@ -40,6 +42,7 @@ export class UnavailableOpticOperationError extends Error {
     super(...params)
 
     // Maintains proper stack trace for where our error was thrown (only available on V8)
+    /* istanbul ignore next */
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, UnavailableOpticOperationError)
     }

--- a/src/operations.js
+++ b/src/operations.js
@@ -278,8 +278,7 @@ export const review = curry((optic, obj) => {
 
 // matches : Fold s a -> s -> Bool
 export const matches = curry((optic, obj) => {
-  if (optic.asGetter) return true
-  else if (optic.asPartialGetter) return preview(optic, obj) !== notFound
+  if (optic.asPartialGetter) return !isNotFound(preview(optic, obj))
   else if (optic.asFold) return reduce(optic, () => true, false, obj)
   else
     throw new UnavailableOpticOperationError(

--- a/src/operations.js
+++ b/src/operations.js
@@ -169,8 +169,6 @@ export const firstOf = (...optics) => {
     return optional(firstOfPreviews(optics1), firstOfSets(optics1))
   } else if (optics1.every((o) => 'asTraversal' in o)) {
     return traversalFromToArray(firstOfToArrays(optics1), firstOfOvers(optics1))
-  } else if (optics1.every((o) => 'asGetter' in o)) {
-    return getter(firstOfOvers(optics1))
   } else if (optics1.every((o) => 'asPartialGetter' in o)) {
     return partialGetter(firstOfPreviews(optics1))
   } else if (optics1.every((o) => 'asFold' in o)) {

--- a/src/operations.js
+++ b/src/operations.js
@@ -26,7 +26,7 @@ const combinePreviews = (p1, p2) => (x) => {
 // r2 comes from Fold b c => ((r -> c -> r) -> r -> b -> r)
 // and we want to get Fold a c => ((r -> c -> r) -> r -> a -> r)
 const combineReduces = (r1, r2) => (f, i, obj) => r2((acc, cur) => r1(f, acc, cur), i, obj)
-const combineToArrays = (t1, t2) => (obj) => t1(obj).flatMap((x) => t2(x))
+const combineToArrays = (t1, t2) => (obj) => t1(obj).flatMap(t2)
 const combineReviews = (r1, r2) => (x) => r1(r2(x))
 
 /**


### PR DESCRIPTION
The idea is to include the other main combinators for optics:
- `sequence` allows you to gather information from several optics:

    ```js
    sequence('id', 'name').toArray({ id: 1, name: 'me' })  // [1, 'me']
    ```

- `firstOf` allows you to attempt a set of `Optionals` and get the first one which matches.

    ```js
    firstOf('name', always('Pepe')).get({ name: 'me' }) // 'me'
    firstOf('name', always('Pepe')).get({ name: 'me' }) // 'Pepe'
    ```